### PR TITLE
Do not attempt to format empty selection

### DIFF
--- a/src/glualintFormatter.ts
+++ b/src/glualintFormatter.ts
@@ -32,7 +32,14 @@ export default class GLuaLintFormatter implements vscode.DocumentFormattingEditP
 
     private formatDocument(doc: vscode.TextDocument, formatOptions: vscode.FormattingOptions, range?: vscode.Range): Promise<vscode.TextEdit[]> {
         if (range === undefined) {
+            // Format entire document.
             range = utils.fullDocumentRange(doc);
+        } else {
+            // If range is empty or the selected text is nothing but whitespaces skip
+            // formatting.
+            if(range.isEmpty || doc.getText(range).trim() == "") {
+                return;
+            }
         }
 
         const indentation = formatOptions.insertSpaces ? ' '.repeat(formatOptions.tabSize) : '\t';


### PR DESCRIPTION
~~This solves the issue, range is not undefined for when there is no selection but passes an empty one. I'm not sure if this is some API change from VSCode but range seems to be never undefined on my end.~~

Rewrote the PR, it now skips the formating if the range is empty or the selected text is nothing but whitespaces.