### PR TITLE
Added an option to lint all files within the workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The linter should now be active for any lua and glua files
 `glualint.linter`: Points to the glualint executable, defaults to `glualint`  
 `glualint.activeLanguages`: Languages IDs to activate the linter for (`lua` and `glua` are supported, defaults to both)  
 `glualint.run`: When to run the linter executable (`onSave`, `onType` or `manual`, defaults to `onType`)
+`glualint.allFiles`: Run the linter on all files in the workspace, even if they are closed. Bypasses `glualint.activeLanguages` setting.
 
 Also see [configuring glualint](https://github.com/FPtje/GLuaFixer/blob/master/README.md#configuring-glualint)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,26 +1,46 @@
 {
     "name": "vscode-glualint",
     "version": "0.10.0",
-    "lockfileVersion": 1,
+    "lockfileVersion": 3,
     "requires": true,
-    "dependencies": {
-        "@types/node": {
+    "packages": {
+        "": {
+            "name": "vscode-glualint",
+            "version": "0.10.0",
+            "license": "MIT",
+            "devDependencies": {
+                "@types/node": "^13.11.1",
+                "@types/vscode": "^1.82.0",
+                "typescript": "^5.2.2"
+            },
+            "engines": {
+                "vscode": "^1.44.0"
+            }
+        },
+        "node_modules/@types/node": {
             "version": "13.11.1",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-13.11.1.tgz",
             "integrity": "sha512-eWQGP3qtxwL8FGneRrC5DwrJLGN4/dH1clNTuLfN81HCrxVtxRjygDTUoZJ5ASlDEeo0ppYFQjQIlXhtXpOn6g==",
             "dev": true
         },
-        "@types/vscode": {
-            "version": "1.44.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.44.0.tgz",
-            "integrity": "sha512-WJZtZlinE3meRdH+I7wTsIhpz/GLhqEQwmPGeh4s1irWLwMzCeTV8WZ+pgPTwrDXoafVUWwo1LiZ9HJVHFlJSQ==",
+        "node_modules/@types/vscode": {
+            "version": "1.84.1",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.84.1.tgz",
+            "integrity": "sha512-DB10vBRLEPA/us7p3gQilU2Tq5HDu6JWTyCpD9qtb7MKWIvJS5In9HU3YgVGCXf/miwHJiY62aXwjtUSMpT8HA==",
             "dev": true
         },
-        "typescript": {
-            "version": "3.8.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
-            "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
-            "dev": true
+        "node_modules/typescript": {
+            "version": "5.2.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+            "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+            "dev": true,
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=14.17"
+            }
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "activationEvents": [
         "onLanguage:lua",
         "onLanguage:glua",
+        "workspaceContains:**/*.lua",
         "onCommand:glualint.lint"
     ],
     "capabilities": {

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     },
     "devDependencies": {
         "@types/node": "^13.11.1",
-        "@types/vscode": "^1.44.0",
-        "typescript": "^3.8.3"
+        "@types/vscode": "^1.82.0",
+        "typescript": "^5.2.2"
     }
 }

--- a/package.json
+++ b/package.json
@@ -71,6 +71,12 @@
                     ],
                     "default": "onType",
                     "description": "Run the linter on save (onSave), on type (onType), or manually with a command (manual)"
+                },
+                "glualint.all_files": {
+                    "type": "boolean",
+                    "scope": "window",
+                    "default": false,
+                    "description": "Run the linter on all files in the workspace, even if they are closed. Bypasses glualint.activeLanguages setting."
                 }
             }
         }

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
                     "type": "string",
                     "scope": "machine-overridable",
                     "default": "glualint",
-                    "description": "Points to the glualint executable"
+                    "markdownDescription": "Points to the `glualint` executable"
                 },
                 "glualint.activeLanguages": {
                     "type": "array",
@@ -59,7 +59,7 @@
                         "glua",
                         "lua"
                     ],
-                    "description": "Languages IDs to activate the linter for"
+                    "markdownDescription": "Languages IDs to activate the linter for"
                 },
                 "glualint.run": {
                     "type": "string",
@@ -70,13 +70,13 @@
                         "manual"
                     ],
                     "default": "onType",
-                    "description": "Run the linter on save (onSave), on type (onType), or manually with a command (manual)"
+                    "markdownDescription": "Run the linter on save (`onSave`), on type (`onType`), or manually with a command (`manual`)"
                 },
-                "glualint.all_files": {
+                "glualint.allFiles": {
                     "type": "boolean",
                     "scope": "window",
                     "default": false,
-                    "description": "Run the linter on all files in the workspace, even if they are closed. Bypasses glualint.activeLanguages setting."
+                    "markdownDescription": "Run the linter on all files in the workspace, even if they are closed. Bypasses `glualint.activeLanguages` setting."
                 }
             }
         }

--- a/src/LintProcess.ts
+++ b/src/LintProcess.ts
@@ -8,14 +8,14 @@ export default class LintProcess {
     public StdOut: string = '';
     public StdErr: string = '';
 
-    constructor(doc: vscode.TextDocument, args: string[] = []) {
+    constructor(docUri: vscode.Uri, args: string[] = []) {
         const config = vscode.workspace.getConfiguration('glualint');
         const executable = config.get<string>('linter');
         const options = {};
 
         // uri.fsPath is only valid for the file scheme
-        if (doc.uri.scheme === 'file') {
-            options['cwd'] = path.dirname(doc.uri.fsPath);
+        if (docUri.scheme === 'file') {
+            options['cwd'] = path.dirname(docUri.fsPath);
         }
 
         this.Process = spawn(executable, args, options);

--- a/src/glualintFormatter.ts
+++ b/src/glualintFormatter.ts
@@ -37,7 +37,7 @@ export default class GLuaLintFormatter implements vscode.DocumentFormattingEditP
 
         const indentation = formatOptions.insertSpaces ? ' '.repeat(formatOptions.tabSize) : '\t';
         const args = ['pretty-print', '--stdin', `--indentation=${indentation}`];
-        const lintProcess: LintProcess = new LintProcess(doc, args);
+        const lintProcess: LintProcess = new LintProcess(doc.uri, args);
 
         if (lintProcess.Process.pid) {
             return new Promise<vscode.TextEdit[]>(resolve => {

--- a/src/glualintProvider.ts
+++ b/src/glualintProvider.ts
@@ -39,7 +39,7 @@ export default class GLuaLintingProvider implements vscode.Disposable {
             }
         }
 
-        const allFiles = config.get<boolean>('all_files');
+        const allFiles = config.get<boolean>('allFiles');
         if (allFiles) {
             // HACK: bypasses activeLanguages setting!
             let files = await vscode.workspace.findFiles("**/*.lua")
@@ -58,7 +58,7 @@ export default class GLuaLintingProvider implements vscode.Disposable {
 
     private onCloseTextDocument(doc: vscode.TextDocument) {
         const config = vscode.workspace.getConfiguration('glualint', null);
-        const allFiles = config.get<boolean>('all_files');
+        const allFiles = config.get<boolean>('allFiles');
 
         if (!allFiles) {
             this.diagnosticCollection.delete(doc.uri);
@@ -112,7 +112,7 @@ export default class GLuaLintingProvider implements vscode.Disposable {
         this.lintUri(doc.uri, doc.getText());
     }
 
-    // TODO: Rate limit this function?
+    // TODO: Rate limit this function? Reuse the linter process?
     private async lintUri(docUri: vscode.Uri, text: string = null) {
         const args = ['lint', '--stdin'];
         const lintProcess: LintProcess = new LintProcess(docUri, args);

--- a/src/glualintProvider.ts
+++ b/src/glualintProvider.ts
@@ -27,8 +27,8 @@ export default class GLuaLintingProvider implements vscode.Disposable {
         const runOn = config.get<string>('run');
 
         if (runOn !== 'manual') {
-            for (let grp of vscode.window.tabGroups.all) {
-                for (let tab of grp.tabs) {
+            for (const grp of vscode.window.tabGroups.all) {
+                for (const tab of grp.tabs) {
                     if (tab.input instanceof vscode.TabInputText) {
                         // HACK: bypasses activeLanguages setting!
                         if (!tab.input.uri.fsPath.endsWith(".lua")) continue;
@@ -42,7 +42,7 @@ export default class GLuaLintingProvider implements vscode.Disposable {
         const allFiles = config.get<boolean>('allFiles');
         if (allFiles) {
             // HACK: bypasses activeLanguages setting!
-            let files = await vscode.workspace.findFiles("**/*.lua")
+            const files = await vscode.workspace.findFiles("**/*.lua")
             files.forEach((fileUri) => this.lintUri(fileUri));
         }
     }
@@ -144,7 +144,7 @@ export default class GLuaLintingProvider implements vscode.Disposable {
             });
 
             if (text == null) {
-                let fileContents = await vscode.workspace.fs.readFile(docUri);
+                const fileContents = await vscode.workspace.fs.readFile(docUri);
                 lintProcess.Process.stdin.end(fileContents);
             } else {
                 lintProcess.Process.stdin.end(Buffer.from(text));

--- a/src/glualintProvider.ts
+++ b/src/glualintProvider.ts
@@ -27,7 +27,19 @@ export default class GLuaLintingProvider implements vscode.Disposable {
         const runOn = config.get<string>('run');
 
         if (runOn !== 'manual') {
-            vscode.workspace.textDocuments.forEach(this.lintDocument, this);
+            for ( let grp of vscode.window.tabGroups.all )
+            {
+                for ( let tab of grp.tabs )
+                {
+                    if ( tab.input instanceof vscode.TabInputText )
+                    {
+                        // HACK: bypasses activeLanguages setting!
+                        if ( !tab.input.uri.fsPath.endsWith( ".lua" ) ) continue;
+
+                        this.lintUri( tab.input.uri );
+                    }
+                }
+            }
         }
     }
 

--- a/src/glualintProvider.ts
+++ b/src/glualintProvider.ts
@@ -27,30 +27,26 @@ export default class GLuaLintingProvider implements vscode.Disposable {
         const runOn = config.get<string>('run');
 
         if (runOn !== 'manual') {
-            for ( let grp of vscode.window.tabGroups.all )
-            {
-                for ( let tab of grp.tabs )
-                {
-                    if ( tab.input instanceof vscode.TabInputText )
-                    {
+            for (let grp of vscode.window.tabGroups.all) {
+                for (let tab of grp.tabs) {
+                    if (tab.input instanceof vscode.TabInputText) {
                         // HACK: bypasses activeLanguages setting!
-                        if ( !tab.input.uri.fsPath.endsWith( ".lua" ) ) continue;
+                        if (!tab.input.uri.fsPath.endsWith(".lua")) continue;
 
-                        this.lintUri( tab.input.uri );
+                        this.lintUri(tab.input.uri);
                     }
                 }
             }
         }
 
         const allFiles = config.get<boolean>('all_files');
-        if ( allFiles )
-        {
+        if (allFiles) {
             const self = this;
             // HACK: bypasses activeLanguages setting!
-            vscode.workspace.findFiles("**/*.lua").then( function(res) {
+            vscode.workspace.findFiles("**/*.lua").then(function(res) {
                 // TODO: Rate limit this?
-                res.forEach( (fileUri) => self.lintUri(fileUri) );
-            } );
+                res.forEach((fileUri) => self.lintUri(fileUri));
+            });
         }
     }
 
@@ -116,11 +112,10 @@ export default class GLuaLintingProvider implements vscode.Disposable {
             return;
         }
 
-        this.lintUri(doc.uri,  doc.getText());
+        this.lintUri(doc.uri, doc.getText());
     }
 
     private lintUri(docUri: vscode.Uri, text: string = null) {
-
         const args = ['lint', '--stdin'];
         const lintProcess: LintProcess = new LintProcess(docUri, args);
 
@@ -150,17 +145,13 @@ export default class GLuaLintingProvider implements vscode.Disposable {
                 }
             });
 
-            if ( text == null )
-            {
-                vscode.workspace.fs.readFile(docUri).then( function(data) {
+            if (text == null) {
+                vscode.workspace.fs.readFile(docUri).then(function(data) {
                     lintProcess.Process.stdin.end(data);
-                } );
-            }
-            else
-            {
+                });
+            } else {
                 lintProcess.Process.stdin.end(Buffer.from(text));
             }
-
         }
     }
 }


### PR DESCRIPTION
This Pull Request adds an option to lint all files within the workspace. There are a few caveats to this however:
* Due to the VSCode API limitations, this bypasses the `glualint.activeLanguages` setting. This _should_ be fine since we target `.lua` files and the linter should handle any such file. I have also mentioned this in the description of the new option.
* With large workspaces, this can be resource intensive on launch. A rate limit might be warranted when linting all files in the workspace, or just in general, perhaps with an option of how many files per second to do.
* Requires restart of VSCode
* I have struggled with making sense of how this should interact with other options. Should all documents be linted on open, or should that be an option instead? i.e. replace `all_files` option with `starting_state` with values of `none`, `opened_documents`, `all_files` or something. What setting would linting on document/tab switch be handled by?

This Pull Request also fixes opened documents not getting linted on editor open, especially when the currently opened document is a non Lua file. This also bypasses `glualint.activeLanguages` due to API limitations.

Please let me know if there are any issues or changes necessary.