### PR TITLE
Improved performance of "all files" setting

### DIFF
--- a/src/LintProcess.ts
+++ b/src/LintProcess.ts
@@ -6,7 +6,6 @@ export default class LintProcess {
     private Process: ChildProcess;
 
     private StdOut: string = '';
-    //private StdErr: string = '';
 
     private ExitFunc: (doc: vscode.Uri, stdOut: string, exitCode: number) => void;
     private document: vscode.Uri;
@@ -37,10 +36,6 @@ export default class LintProcess {
             this.StdOut += buffer;
         });
 
-        /*this.Process.stderr.on('data', buffer => {
-            this.StdErr += buffer;
-        });*/
-    
         this.Process.on('exit', code => {
             this.ExitFunc(this.document, this.StdOut, code);
         });

--- a/src/LintProcess.ts
+++ b/src/LintProcess.ts
@@ -8,6 +8,7 @@ export default class LintProcess {
     private StdOut: string = '';
 
     private ExitFunc: (doc: vscode.Uri, stdOut: string, exitCode: number) => void;
+    private PromiseFunc: () => void;
     private document: vscode.Uri;
 
     constructor(docUri: vscode.Uri, args: string[] = []) {
@@ -38,6 +39,13 @@ export default class LintProcess {
 
         this.Process.on('exit', code => {
             this.ExitFunc(this.document, this.StdOut, code);
+            if (this.PromiseFunc) this.PromiseFunc();
+        });
+    }
+
+    async waitForProcessExit() {
+        return new Promise<void>((res, rej) => {
+            this.PromiseFunc = res;
         });
     }
 

--- a/src/glualintProvider.ts
+++ b/src/glualintProvider.ts
@@ -42,7 +42,13 @@ export default class GLuaLintingProvider implements vscode.Disposable {
 
             // Group all files by the directories they are in
             const groups: {[id: string]: vscode.Uri[];} = {};
+            const virtualFiles: vscode.Uri[] = [];
             for (const file of allFiles) {
+                if (file.scheme !== "file") {
+                    virtualFiles.push(file);
+                    continue;
+                }
+
                 const fullPath = path.dirname(file.fsPath);
                 if (!groups[fullPath]) groups[fullPath] = [];
                 groups[fullPath].push(file);
@@ -51,6 +57,9 @@ export default class GLuaLintingProvider implements vscode.Disposable {
             // Lint by directory
             for (const [group, files] of Object.entries(groups)) {
                 this.lintFolder(group, files);
+            }
+            for (const file of virtualFiles) {
+                this.lintUri(file);
             }
         }
 

--- a/src/glualintProvider.ts
+++ b/src/glualintProvider.ts
@@ -149,7 +149,7 @@ export default class GLuaLintingProvider implements vscode.Disposable {
 
         const lintProcess: LintProcess = new LintProcess(uris[0], args);
         if (!lintProcess.isValid()) {
-            // TODO: User friendly warning?
+            vscode.window.showErrorMessage('Failed to create linter process.');
             return;
         }
 
@@ -186,7 +186,7 @@ export default class GLuaLintingProvider implements vscode.Disposable {
         const args = ['lint', '--stdin'];
         const lintProcess: LintProcess = new LintProcess(docUri, args);
         if (!lintProcess.isValid()) {
-            // TODO: User friendly warning?
+            vscode.window.showErrorMessage('Failed to create linter process.');
             return;
         }
 

--- a/src/glualintProvider.ts
+++ b/src/glualintProvider.ts
@@ -2,6 +2,7 @@
 
 import * as vscode from 'vscode';
 import LintProcess from './LintProcess';
+import * as path from 'path';
 
 const OUTPUT_REGEXP = /^(.+?): \[(Error|Warning)\] line (\d+), column (\d+)(?: - line (\d+), column (\d+))?: (.+)/gm;
 
@@ -32,6 +33,28 @@ export default class GLuaLintingProvider implements vscode.Disposable {
 
         const config = vscode.workspace.getConfiguration('glualint');
 
+        // First all files
+        const allFiles = config.get<boolean>('allFiles');
+        if (allFiles) {
+            // HACK: bypasses activeLanguages setting!
+            const allFiles = await vscode.workspace.findFiles('**/*.lua');
+            console.log('vscode-glualint: Linting ' + allFiles.length + ' file(s)...');
+
+            // Group all files by the directories they are in
+            const groups: {[id: string]: vscode.Uri[];} = {};
+            for (const file of allFiles) {
+                const fullPath = path.dirname(file.fsPath);
+                if (!groups[fullPath]) groups[fullPath] = [];
+                groups[fullPath].push(file);
+            }
+
+            // Lint by directory
+            for (const [group, files] of Object.entries(groups)) {
+                this.lintFolder(group, files);
+            }
+        }
+
+        // Then (ideally) any open ediots, which may be edited
         const runOn = config.get<string>('run');
         if (runOn !== 'manual') {
             for (const grp of vscode.window.tabGroups.all) {
@@ -44,13 +67,6 @@ export default class GLuaLintingProvider implements vscode.Disposable {
                     }
                 }
             }
-        }
-
-        const allFiles = config.get<boolean>('allFiles');
-        if (allFiles) {
-            // HACK: bypasses activeLanguages setting!
-            const files = await vscode.workspace.findFiles('**/*.lua')
-            files.forEach((fileUri) => this.lintUri(fileUri));
         }
     }
 
@@ -125,11 +141,28 @@ export default class GLuaLintingProvider implements vscode.Disposable {
         this.lintUri(doc.uri, doc.getText());
     }
 
-    // TODO: Rate limit this function? Reuse the linter process?
-    private async lintUri(docUri: vscode.Uri, text: string = null) {
+    private lintFolder(folder: string, uris: vscode.Uri[]) {
+        let args = ['lint'];
+        for (const file of uris) {
+            args.push(file.fsPath.substring(folder.length + 1));
+        }
+
+        const lintProcess: LintProcess = new LintProcess(uris[0], args);
+        if (!lintProcess.isValid()) {
+            // TODO: User friendly warning?
+            return;
+        }
+
+        lintProcess.onExit((url, stdOut, code) => {
+            this.onReceiveDiagnostics(uris, stdOut, code);
+        });
+    }
+
+    // TODO: Rate limit creating new processes? Reuse the linter process somehow?
+    private async lintUri(docUri: vscode.Uri, text?: string) {
         // First get the text..
         let textBuf: any = null;
-        if (text == null) {
+        if (text === undefined) {
             try {
                 textBuf = await vscode.workspace.fs.readFile(docUri);
             } catch(e) {
@@ -142,7 +175,7 @@ export default class GLuaLintingProvider implements vscode.Disposable {
                     }
                 }
 
-                console.warn('Failed to lint', e);
+                console.warn('vscode-glualint: Failed to lint', e);
                 return;
             }
         } else {
@@ -152,36 +185,58 @@ export default class GLuaLintingProvider implements vscode.Disposable {
         // Perform the actual linting
         const args = ['lint', '--stdin'];
         const lintProcess: LintProcess = new LintProcess(docUri, args);
-        if (!lintProcess.Process.pid) {
+        if (!lintProcess.isValid()) {
             // TODO: User friendly warning?
             return;
         }
 
-        lintProcess.Process.on('exit', () => {
-            const diagnostics: vscode.Diagnostic[] = [];
-
-            let match: RegExpExecArray;
-            // tslint:disable-next-line:no-conditional-assignment
-            while ((match = OUTPUT_REGEXP.exec(lintProcess.StdOut)) !== null) {
-                // let file = match[1];
-                const type = match[2];
-                const line = parseInt(match[3], 10) - 1;
-                const col = parseInt(match[4], 10) - 1;
-                const endLine = match[5] !== undefined ? parseInt(match[5], 10) - 1 : line;
-                const endCol = match[6] !== undefined ? parseInt(match[6], 10) - 1 : col + 1;
-                const text = match[7];
-
-                const range = new vscode.Range(line, col, endLine, endCol);
-                diagnostics.push(new vscode.Diagnostic(range, text, type === 'Warning' ? vscode.DiagnosticSeverity.Warning : vscode.DiagnosticSeverity.Error));
-            }
-
-            if (diagnostics.length === 0) {
-                this.diagnosticCollection.delete(docUri);
-            } else {
-                this.diagnosticCollection.set(docUri, diagnostics);
-            }
+        lintProcess.onExit((url, stdOut, code) => {
+            this.onReceiveDiagnostics([url], stdOut, code);
         });
+        lintProcess.write(textBuf);
+    }
 
-        lintProcess.Process.stdin.end(textBuf);
+    private async onReceiveDiagnostics(docUris: vscode.Uri[], stdOut: string, exitCode: number) {
+        const diagnostics: {[id: string]: vscode.Diagnostic[];} = {};
+
+        let match: RegExpExecArray;
+        // tslint:disable-next-line:no-conditional-assignment
+        while ((match = OUTPUT_REGEXP.exec(stdOut)) !== null) {
+            const file = match[1];
+            const type = match[2];
+            const line = parseInt(match[3], 10) - 1;
+            const col = parseInt(match[4], 10) - 1;
+            const endLine = match[5] !== undefined ? parseInt(match[5], 10) - 1 : line;
+            const endCol = match[6] !== undefined ? parseInt(match[6], 10) - 1 : col + 1;
+            const text = match[7];
+
+            const range = new vscode.Range(line, col, endLine, endCol);
+            const diagnostic = new vscode.Diagnostic(range, text, type === 'Warning' ? vscode.DiagnosticSeverity.Warning : vscode.DiagnosticSeverity.Error);
+
+            if (!diagnostics[file]) diagnostics[file] = [];
+            diagnostics[file].push(diagnostic);
+        }
+
+        // Special case for lintUri
+        if (diagnostics['stdin']) {
+            const fileName = path.basename(docUris[0].fsPath);
+            diagnostics[fileName] = diagnostics['stdin'];
+            delete diagnostics['stdin'];
+        }
+
+        for (const file of docUris) {
+            const fileName = path.basename(file.fsPath);
+            const fileDiagnostics = diagnostics[fileName];
+            if (!fileDiagnostics || fileDiagnostics.length === 0) {
+                this.diagnosticCollection.delete(file);
+            } else {
+                this.diagnosticCollection.set(file, fileDiagnostics);
+            }
+            delete diagnostics[fileName];
+        }
+
+        if (Object.keys(diagnostics).length > 0) {
+            vscode.window.showErrorMessage('This should never happen: Got extra data when linting folders.');
+        }
     }
 }


### PR DESCRIPTION
Use `glualinter`'s ability to lint multiple files at once to severely cut down on number of processes spawned.

For GMod's base Lua code, the number goes from 619 to around 60, which significantly improves performance on Windows.

Related discussion: https://github.com/FPtje/GLuaFixer/issues/175